### PR TITLE
Add Sampler protocol & ConstantSampler conformance

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/slashmo/swift-w3c-trace-context.git",
         "state": {
           "branch": null,
-          "revision": "34dee324fa9a73ff43397dd5bff42af8d207a01c",
-          "version": "0.4.0"
+          "revision": "8502b4cd58abe48220e6ef383eceb5694253081f",
+          "version": "0.5.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(name: "swift-context", url: "https://github.com/slashmo/gsoc-swift-baggage-context", from: "0.5.0"),
         .package(url: "https://github.com/slashmo/gsoc-swift-tracing.git", .branch("main")),
-        .package(url: "https://github.com/slashmo/swift-w3c-trace-context.git", from: "0.4.0"),
+        .package(url: "https://github.com/slashmo/swift-w3c-trace-context.git", from: "0.5.0"),
         .package(url: "https://github.com/slashmo/swift-nio.git", .branch("feature/baggage-context")),
     ],
     targets: [

--- a/Sources/Jaeger/JaegerSpan.swift
+++ b/Sources/Jaeger/JaegerSpan.swift
@@ -18,7 +18,11 @@ import W3CTraceContext
 
 public final class JaegerSpan: Span {
     public var attributes: SpanAttributes = [:]
-    public private(set) var isRecording: Bool
+
+    public var isRecording: Bool {
+        self.baggage.traceContext?.sampled ?? false
+    }
+
     public let startTimestamp: Timestamp
     public let baggage: Baggage
     public private(set) var endTimestamp: Timestamp?
@@ -40,19 +44,7 @@ public final class JaegerSpan: Span {
         self.kind = kind
         self.startTimestamp = startTimestamp
         self.onReport = onReport
-
-        if baggage.traceContext != nil {
-            var childBaggage = baggage
-            childBaggage.traceContext?.regenerateParentID()
-            self.baggage = childBaggage
-            self.isRecording = false
-            self.addLink(SpanLink(baggage: baggage))
-        } else {
-            var baggage = baggage
-            baggage.traceContext = TraceContext(parent: .random(), state: .none)
-            self.baggage = baggage
-            self.isRecording = true
-        }
+        self.baggage = baggage
     }
 
     public func setStatus(_ status: SpanStatus) {}

--- a/Sources/Jaeger/Sampling/ConstantSampler.swift
+++ b/Sources/Jaeger/Sampling/ConstantSampler.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Jaeger Client Swift open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Jaeger Client Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public final class ConstantSampler: Sampler {
+    private let samples: Bool
+
+    public init(samples: Bool) {
+        self.samples = samples
+    }
+
+    public func sample(operationName: String, traceID: String) -> SamplingStatus {
+        SamplingStatus(isSampled: self.samples, attributes: [
+            "sampler.type": "const",
+            "sampler.param": self.samples ? "true" : "false",
+        ])
+    }
+}

--- a/Sources/Jaeger/Sampling/ConstantSampler.swift
+++ b/Sources/Jaeger/Sampling/ConstantSampler.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public final class ConstantSampler: Sampler {
+public struct ConstantSampler: Sampler {
     private let samples: Bool
 
     public init(samples: Bool) {

--- a/Sources/Jaeger/Sampling/Sampler.swift
+++ b/Sources/Jaeger/Sampling/Sampler.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Jaeger Client Swift open source project
+//
+// Copyright (c) 2020 Moritz Lang and the Jaeger Client Swift project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+public struct SamplingStatus {
+    var isSampled: Bool
+    var attributes: SpanAttributes
+}
+
+public protocol Sampler {
+    func sample(operationName: String, traceID: String) -> SamplingStatus
+}

--- a/Sources/Jaeger/Settings.swift
+++ b/Sources/Jaeger/Settings.swift
@@ -18,6 +18,7 @@ extension JaegerTracer {
     public struct Settings {
         public let serviceName: String
         public let reporter: Reporter
+        public let sampler: Sampler
         public let logger: Logger
 
         public var flushInterval: TimeAmount
@@ -28,6 +29,7 @@ extension JaegerTracer {
         public init(
             serviceName: String,
             reporter: Reporter,
+            sampler: Sampler,
             logger: Logger = Logger(label: "JaegerTracer"),
             flushInterval: TimeAmount = .seconds(1),
             flushTimeout: TimeAmount = .seconds(5),
@@ -36,6 +38,7 @@ extension JaegerTracer {
         ) {
             self.serviceName = serviceName
             self.reporter = reporter
+            self.sampler = sampler
             self.logger = logger
             self.flushInterval = flushInterval
             self.flushTimeout = flushTimeout

--- a/Tests/JaegerTests/JaegerSpanTests.swift
+++ b/Tests/JaegerTests/JaegerSpanTests.swift
@@ -18,12 +18,6 @@ import W3CTraceContext
 import XCTest
 
 final class JaegerSpanTests: XCTestCase {
-    func test_adds_trace_context_if_not_yet_recorded() {
-        let span = JaegerSpan()
-
-        XCTAssertNotNil(span.baggage.traceContext)
-    }
-
     func test_recordError_sets_exception_attributes() {
         let span = JaegerSpan()
         XCTAssertEqual(span.attributes, [:])
@@ -58,26 +52,6 @@ final class JaegerSpanTests: XCTestCase {
         span.end()
 
         XCTAssertEqual(invocationCount, 1)
-    }
-
-    func test_creates_trace_context_for_root_span() {
-        let span = JaegerSpan()
-
-        XCTAssertNotNil(span.baggage.traceContext)
-    }
-
-    func test_regenerates_parent_id_in_existing_trace_context() {
-        var baggage = Baggage.topLevel
-        baggage.traceContext = TraceContext(parent: .random(), state: TraceState(rawValue: "rojo=123")!)
-
-        let span = JaegerSpan(baggage: baggage)
-
-        XCTAssertNotNil(span.baggage.traceContext)
-        XCTAssertEqual(span.baggage.traceContext?.state, baggage.traceContext?.state)
-        XCTAssertEqual(span.baggage.traceContext?.parent.traceID, baggage.traceContext?.parent.traceID)
-        XCTAssertNotEqual(span.baggage.traceContext?.parent.parentID, baggage.traceContext?.parent.parentID)
-        XCTAssertEqual(span.baggage.traceContext?.parent.traceFlags, baggage.traceContext?.parent.traceFlags)
-        XCTAssertEqual(span.links.first?.baggage.traceContext, baggage.traceContext)
     }
 }
 

--- a/Tests/JaegerTests/JaegerTracerTests.swift
+++ b/Tests/JaegerTests/JaegerTracerTests.swift
@@ -27,7 +27,7 @@ final class JaegerTracerTests: XCTestCase {
     func test_extract_w3c_trace_context_into_baggage() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         let traceContext = TraceContext(parent: .random(), state: .none)
@@ -45,7 +45,7 @@ final class JaegerTracerTests: XCTestCase {
     func test_extract_missing_w3c_trace_context_into_baggage() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         var baggage = Baggage.topLevel
@@ -58,7 +58,7 @@ final class JaegerTracerTests: XCTestCase {
     func test_extract_missing_w3c_trace_context_without_state_into_baggage() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         let traceContext = TraceContext(parent: .random(), state: .none)
@@ -76,7 +76,7 @@ final class JaegerTracerTests: XCTestCase {
     func test_inject_w3c_trace_context_into_headers() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         let traceContext = TraceContext(parent: .random(), state: .none)
@@ -94,7 +94,7 @@ final class JaegerTracerTests: XCTestCase {
     func test_inject_missing_w3c_trace_context_into_headers() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         let baggage = Baggage.topLevel
@@ -105,13 +105,43 @@ final class JaegerTracerTests: XCTestCase {
         XCTAssertTrue(headers.isEmpty)
     }
 
+    func test_creates_trace_context_for_root_span() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
+        let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
+
+        let span = tracer.startSpan(named: "test", baggage: .topLevel, ofKind: .server, at: .now())
+        XCTAssertNotNil(span.baggage.traceContext)
+    }
+
+    func test_regenerates_parent_id_in_existing_trace_context() {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
+        let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
+
+        var parentBaggage = Baggage.topLevel
+        parentBaggage.traceContext = TraceContext(parent: .random(), state: TraceState(rawValue: "rojo=123")!)
+
+        let parent = tracer.startSpan(named: "test", baggage: parentBaggage, ofKind: .server, at: .now()) as! JaegerSpan
+        let child = tracer.startSpan(named: "test", baggage: parent.baggage, ofKind: .server, at: .now()) as! JaegerSpan
+
+        XCTAssertNotNil(child.baggage.traceContext)
+        XCTAssertEqual(child.baggage.traceContext?.state, parentBaggage.traceContext?.state)
+        XCTAssertEqual(child.baggage.traceContext?.parent.traceID, parentBaggage.traceContext?.parent.traceID)
+        XCTAssertNotEqual(child.baggage.traceContext?.parent.parentID, parentBaggage.traceContext?.parent.parentID)
+        XCTAssertEqual(child.baggage.traceContext?.parent.traceFlags, parentBaggage.traceContext?.parent.traceFlags)
+        XCTAssertEqual(child.links.first?.baggage.traceContext, parent.baggage.traceContext)
+    }
+
     // MARK: - Flushing
 
     func test_emits_spans_to_reporter_on_forceFlush() {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let reporter = TestSpanReporter(eventLoop: eventLoopGroup.next())
 
-        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter))
+        let settings = JaegerTracer.Settings(serviceName: "test", reporter: .custom(reporter), sampler: ConstantSampler(samples: false))
         let tracer = JaegerTracer(settings: settings, group: eventLoopGroup)
 
         var spans = [JaegerSpan]()


### PR DESCRIPTION
This PR lays the foundation for sampling. It adds a `Sampler` protocol with the simplest of conformances, the `ConstantSampler`. Other than that, it's now `JaegerTracer`s responsibility to update the `TraceContext` of a span it's starting. Therefore, the `JaegerSpan` initializer becomes simpler and assigns arguments to stored properties.

Closes #2 